### PR TITLE
Fix dtool and detecttool imports

### DIFF
--- a/ibeis_cnn/ingest_ibeis.py
+++ b/ibeis_cnn/ingest_ibeis.py
@@ -8,7 +8,7 @@ import cv2
 import itertools
 from six.moves import zip, map, range
 from functools import partial
-import dtool
+from ibeis import dtool
 from ibeis_cnn import draw_results  # NOQA
 print, rrr, profile = ut.inject2(__name__)
 

--- a/ibeis_cnn/process.py
+++ b/ibeis_cnn/process.py
@@ -3,7 +3,7 @@
 
 """
 from __future__ import absolute_import, division, print_function
-from detecttools.directory import Directory
+from ibeis.detecttools.directory import Directory
 from os.path import join, abspath, exists, basename
 import utool as ut
 import cv2


### PR DESCRIPTION
- Fix dtool import in ingest_ibeis.py

  dtool used to be a separate package but has been moved into ibeis, so
  imports need to change from `import dtool` to `from ibeis import dtool`.

- Fix detecttool import in process.py

  detecttool used to be a separate package but has been moved into ibeis.
  Imports need to change from `from detecttool` to
  `from ibeis.detecttool`.
