### PR TITLE
[Tests failed] Downgrade requirements: lasagne 0.1 and theano 0.8.2

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,7 +1,7 @@
-git+https://github.com/Lasagne/Lasagne.git#egg=lasagne
+lasagne==0.1  # latest version on pypi
 requests>=0.8.2; python_version < '3'
 scikit-learn>=0.16.1
-theano
+theano==0.8.2  # latest version that works with lasagne 0.1
 wbia-utool
 wbia-vtool
 # h5py  # Install this instead sudo apt-get install libhdf5-dev due to Numpy versioning issues


### PR DESCRIPTION
Lasagne on github works with the latest Theano but it's not released to
pypi which means we can't just do `pip install wbia-cnn`.

We decided to use the latest released version of lasagne with the latest
version of Theano that works with it instead.

**Note**: WIP while checking whether wildbook-ia tests still pass
**Edit:** tests failed, see https://github.com/WildbookOrg/wbia-plugin-cnn/pull/9#issuecomment-678428215